### PR TITLE
Fixed isECCertsCMExist & isECSecretExists function

### DIFF
--- a/k8s/ec-service/templates/_helpers.tpl
+++ b/k8s/ec-service/templates/_helpers.tpl
@@ -121,27 +121,20 @@ rules:
 {{- end }}
 {{- end -}}
 
-{{/*
-Function to get the existence of ConfigMap component for root certs
-*/}}
+{{/* Function to get the existence of ConfigMap component for root certs */}}
 {{- define "ec-service.isECCertsCMExist" -}}
-{{- $configmap := (lookup "v1" "ConfigMap" .Release.Namespace .Values.global.ecCertsConfigmapName) }}
-{{- if $configmap }}
-{{- printf "Exists" }}
+{{- if (lookup "v1" "ConfigMap" .Release.Namespace .Values.global.ecCertsConfigmapName) }}
+{{- print "Exists" }}
 {{- else }}
-{{- printf "Not Exists" }}
-{{- end }}
+{{- print "Not Exists" }}
+{{- end -}}
 {{- end -}}
 
-
-{{/*
-Function to get the existence of ec secrets component
-*/}}
+{{/* Function to get the existence of ec secrets component */}}
 {{- define "ec-service.isECSecretExist" -}}
-{{- $ecsecret := (lookup "v1" "Secret" .Release.Namespace .Values.global.ecSecretName) }}
-{{- if $ecsecret }}
-{{- printf "Exists" }}
+{{- if (lookup "v1" "Secret" .Release.Namespace .Values.global.ecSecretName) }}
+{{- print "Exists" }}
 {{- else }}
-{{- printf "Not Exists" }}
-{{- end }}
+{{- print "Not Exists" }}
+{{- end -}}
 {{- end -}}

--- a/k8s/ec-service/templates/deployment.yaml
+++ b/k8s/ec-service/templates/deployment.yaml
@@ -1,6 +1,3 @@
-{{- $isCertsConfigMapExist := include "ec-service.isECCertsCMExist" . -}}
-{{- $isECSecretExist := include "ec-service.isECSecretExist" . -}}
-{{- if and (eq "Exists" $isCertsConfigMapExist) (eq "Exists" $isECSecretExist) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -98,4 +95,3 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-{{- end }}


### PR DESCRIPTION
- Fixed the logic in helpers.tpl > isECCertsCMExist & isECSecretExists functions to check for ec-certs and ec-secret objects exists in the cluster before installing the helm chart.
- Removed IF condition in deployment.yaml to check ec-certs and ec-secret before creating the pod.  Argo-cd might be using helm template and not evaluating this condition whehn synced.  Created an issue in GitHub for future tracking.
